### PR TITLE
Use translation reference

### DIFF
--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -28,7 +28,7 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['timeline_orientation'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_content']['timeline_orientation'],
     'exclude' => true,
     'inputType' => 'select',
-    'options' => $GLOBALS['TL_LANG']['tl_content']['timeline_orientation']['options'],
+    'options' => &$GLOBALS['TL_LANG']['tl_content']['timeline_orientation']['options'],
     'eval' => ['includeBlankOption' => true, 'chosen' => true, 'tl_class' => 'w50'],
     'sql' => "TEXT null",
 ];


### PR DESCRIPTION
Fixes the following error:

```
  [ErrorException]
  Warning: Trying to access array offset on value of type null  


Exception trace:
  at vendor\pdir\animated-timeline-bundle\src\Resources\contao\dca\tl_content.php:31
```

This can happen if a DCA is loaded without the language being loaded before hand (e.g. during migrations).