### PR TITLE
fix: add TimelineElementListeners for multiSRC field handling

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -11,3 +11,6 @@ services:
         Symfony\Component\DependencyInjection\ContainerAwareInterface:
             calls:
                 - ["setContainer", ["@service_container"]]
+
+    Pdir\AnimatedTimelineBundle\:
+        resource: ../src/*

--- a/contao/dca/tl_content.php
+++ b/contao/dca/tl_content.php
@@ -126,5 +126,3 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['timeline_navPos'] = [
     'eval' => ['chosen' => true, 'tl_class' => 'w50'],
     'sql' => 'TEXT null default "bottom"',
 ];
-
-$GLOBALS['TL_DCA']['tl_content']['fields']['multiSRC']['eval']['isGallery'] = 'true';

--- a/src/EventListener/DataContainer/TimelineElementListeners.php
+++ b/src/EventListener/DataContainer/TimelineElementListeners.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pdir\AnimatedTimelineBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\DataContainer;
+
+class TimelineElementListeners
+{
+    #[AsCallback('tl_content', 'fields.multiSRC.load')]
+    public function setMultiSRCFlags(mixed $varValue, DataContainer $dc): mixed
+    {
+        if ($dc->activeRecord && $dc->activeRecord->type === 'timelineSliderElement') {
+            $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
+        }
+        return $varValue;
+    }
+}


### PR DESCRIPTION
Introduced a new listener class TimelineElementListeners to handle the multiSRC field for timeline elements. Also updated the services configuration and removed redundant entry from tl_content. This ensures the isGallery flag is dynamically set based on the element type.

Fixes #13 